### PR TITLE
change: modal easing function.

### DIFF
--- a/lib/framerVariants/mobileNavVariants.ts
+++ b/lib/framerVariants/mobileNavVariants.ts
@@ -18,7 +18,7 @@ export const containerVariants: Variants = {
     x: '-100%',
     transition: {
       duration: 0.4,
-      ease: [0.49, -0.07, 0.82, 0.68],
+      ease: [0.49, -0.02, 0.82, 0.68],
       staggerDirection: 1,
       staggerChildren: 0.04,
       when: 'afterChildren',


### PR DESCRIPTION
Change the easing function slightly so when the mobile navigation modal is closing it doesn't show a gap on the left side of the screen on some browsers.